### PR TITLE
Change homepage link to point at current directory instead of web root.

### DIFF
--- a/bootstrap/index.html
+++ b/bootstrap/index.html
@@ -19,7 +19,7 @@
         </div>
         <div class="collapse navbar-collapse navbar-styleguide-collapse">
           <ul class="nav navbar-nav navbar-right">
-            <li><a href="/">Home</a></li>
+            <li><a href="./">Home</a></li>
             {{#eachRoot}}
               <li>
                 <a href="section-{{referenceURI}}.html"><!--{{referenceURI}}.0: -->{{header}}</a>


### PR DESCRIPTION
In the generated style guide, the link to the homepage is set to `/`. But that assumes that the webroot is the same as the style guide root. That's not always the case.

For example, I put my style guide in a sub-directory of a Drupal installation.

If we change the link from `/` to `./` then it will work under both conditions.