### PR TITLE
Add clearfix CSS to kss-example class to prevent floats from overflowing

### DIFF
--- a/bootstrap/public/kss.css
+++ b/bootstrap/public/kss.css
@@ -11,6 +11,12 @@ footer {
   min-height: 4em;
   position: relative;
 }
+.kss-example:after,
+.kss-example:before {
+  clear: both;
+  content: " ";
+  display: table;
+}
 
 /**
  * Off Canvas


### PR DESCRIPTION
The `.kss-example` class is added to the wrapper around a style guide example. If the example has floating elements, they can overflow the wrapper.

So we should add clearfix styling to the kss-example wrapper.