### PR TITLE
Add kss-node weights to make section ordering match official docs

### DIFF
--- a/styleguide/components/alert.css
+++ b/styleguide/components/alert.css
@@ -12,5 +12,7 @@ Markup:
 .alert-warning - Warning
 .alert-danger - Danger
 
+Weight: 15
+
 Styleguide components.alert
 */

--- a/styleguide/components/badge.css
+++ b/styleguide/components/badge.css
@@ -6,5 +6,7 @@ Easily highlight new or unread items by adding a <code>&lt;span class="badge"&gt
 Markup:
 <a href="#">Inbox <span class="badge">42</span></a>
 
+Weight: 11
+
 Styleguide components.badge
 */

--- a/styleguide/components/breadcrumb.css
+++ b/styleguide/components/breadcrumb.css
@@ -10,5 +10,7 @@ Markup:
   <li class="active">Data</li>
 </ol>
 
+Weight: 8
+
 Styleguide components.breadcrumb
 */

--- a/styleguide/components/btn-group.css
+++ b/styleguide/components/btn-group.css
@@ -14,5 +14,7 @@ Markup:
 .btn-group-sm - Small
 .btn-group-xs - Extra small
 
+Weight: 3
+
 Styleguide components.btn-group
 */

--- a/styleguide/components/dropdown.css
+++ b/styleguide/components/dropdown.css
@@ -17,5 +17,7 @@ Markup:
   </ul>
 </div>
 
+Weight: 2
+
 Styleguide components.dropdown
 */

--- a/styleguide/components/jumbotron.css
+++ b/styleguide/components/jumbotron.css
@@ -12,5 +12,7 @@ Markup:
   </div>
 </div>
 
+Weight: 12
+
 Styleguide components.jumbotron
 */

--- a/styleguide/components/label.css
+++ b/styleguide/components/label.css
@@ -13,5 +13,7 @@ Markup:
 .label-warning - Warning
 .label-danger - Danger
 
+Weight: 10
+
 Styleguide components.label
 */

--- a/styleguide/components/list-group.css
+++ b/styleguide/components/list-group.css
@@ -12,6 +12,8 @@ Markup:
   <li class="list-group-item">Vestibulum at eros</li>
 </ul>
 
+Weight: 18
+
 Styleguide components.list-group
 */
 

--- a/styleguide/components/media.css
+++ b/styleguide/components/media.css
@@ -14,5 +14,7 @@ Markup:
   </div>
 </div>
 
+Weight: 17
+
 Styleguide components.media
 */

--- a/styleguide/components/nav.css
+++ b/styleguide/components/nav.css
@@ -17,5 +17,7 @@ Markup:
 .nav-tabs.nav-justified - Justified navigation
 .nav-pills.nav-justified - Pill and justified navigation
 
+Weight: 6
+
 Styleguide components.nav
 */

--- a/styleguide/components/pagination.css
+++ b/styleguide/components/pagination.css
@@ -19,5 +19,7 @@ Markup:
 .pagination-lg - Large
 .pagination-sm - Small
 
+Weight: 9
+
 Styleguide components.pagination
 */

--- a/styleguide/components/panel.css
+++ b/styleguide/components/panel.css
@@ -3,6 +3,8 @@ Panels
 
 While not always necessary, sometimes you need to put your DOM in a box. For those situations, try the panel component.
 
+Weight: 19
+
 Styleguide components.panel
 */
 
@@ -60,6 +62,8 @@ Markup:
   <div class="panel-footer">Panel footer</div>
 </div>
 
+Weight: 1
+
 Styleguide components.panel.footer
 */
 
@@ -83,6 +87,8 @@ Markup:
 .panel-info - Information
 .panel-warning - Warning
 .panel-danger - Danger
+
+Weight: 2
 
 Styleguide components.panel.contextual
 */

--- a/styleguide/components/progress.css
+++ b/styleguide/components/progress.css
@@ -15,6 +15,8 @@ Markup:
 .progress-bar-warning - Warning
 .progress-bar-danger - Danger
 
+Weight: 16
+
 Styleguide components.progress
 */
 
@@ -82,6 +84,8 @@ Markup:
 
 .active - Animate by adding <code>.active</code> to <code>.progress-bar-striped</code>.
 
+Weight: 1
+
 Styleguide components.progress.striped
 */
 
@@ -102,6 +106,8 @@ Markup:
     <span class="sr-only">10% Complete (danger)</span>
   </div>
 </div>
+
+Weight: 2
 
 Styleguide components.progress.stacked
 */

--- a/styleguide/css/button.css
+++ b/styleguide/css/button.css
@@ -13,6 +13,8 @@ Markup:
 .btn-danger - Danger
 .btn-link - Link
 
+Weight: 6
+
 Styleguide css.button
 */
 

--- a/styleguide/css/code.css
+++ b/styleguide/css/code.css
@@ -6,6 +6,8 @@ Wrap inline snippets of code with <code>&lt;code&gt;</code>.
 Markup:
 For example, <code>&lt;section&gt;</code> should be wrapped as inline.
 
+Weight: 3
+
 Styleguide css.code
 */
 
@@ -28,6 +30,8 @@ Use &lt;pre&gt; for multiple lines of code. Be sure to escape any angle brackets
 
 Markup:
 <pre>&lt;p&gt;Sample text here...&lt;/p&gt;</pre>
+
+Weight: 1
 
 Styleguide css.code.basic
 */

--- a/styleguide/css/form.css
+++ b/styleguide/css/form.css
@@ -7,5 +7,7 @@ Markup: form.hbs
 
 .form-inline - Inline forms
 
+Weight: 5
+
 Styleguide css.form
 */

--- a/styleguide/css/helper.css
+++ b/styleguide/css/helper.css
@@ -3,6 +3,8 @@ Helpers
 
 There are many helper classes available.
 
+Weight: 8
+
 Styleguide css.helper
 */
 
@@ -34,6 +36,8 @@ Markup:
 <p class="bg-warning">Etiam porta sem malesuada magna mollis euismod.</p>
 <p class="bg-danger">Donec ullamcorper nulla non metus auctor fringilla.</p>
 
+Weight: 1
+
 Styleguide css.helper.background
 */
 
@@ -45,6 +49,8 @@ Use the generic close icon for dismissing content like modals and alerts.
 Markup:
 <button type="button" class="close"><span aria-hidden="true">&times;</span><span class="sr-only">Close</span></button>
 
+Weight: 1
+
 Styleguide css.helper.close
 */
 
@@ -55,6 +61,8 @@ Use carets to indicate dropdown functionality and direction. Note that the defau
 
 Markup:
 <span class="caret"></span>
+
+Weight: 2
 
 Styleguide css.helper.caret
 */

--- a/styleguide/css/image.css
+++ b/styleguide/css/image.css
@@ -3,6 +3,8 @@ Images
 
 There are a number of ways to expose images.
 
+Weight: 7
+
 Styleguide css.image
 */
 

--- a/styleguide/css/table.css
+++ b/styleguide/css/table.css
@@ -10,6 +10,8 @@ Markup: table.hbs
 .table-hover - Add <code>.table-hover</code> to enable a hover state on table rows within a &lt;tbody&gt;.
 .table-condensed - Add <code>.table-condensed</code> to make tables more compact by cutting cell padding in half.
 
+Weight: 4
+
 Styleguide css.table
 */
 

--- a/styleguide/css/typography.css
+++ b/styleguide/css/typography.css
@@ -3,6 +3,8 @@ Typography
 
 The below provides typographical styles that are present across the site.
 
+Weight: 2
+
 Styleguide css.typography
 */
 
@@ -49,6 +51,8 @@ lovably dim wiki-girl. Watch "Jeopardy!", Alex Trebek's fun TV quiz game. How
 razorback-jumping frogs can level six piqued gymnasts! All questions asked by
 five watched experts — amaze the judge.</p>
 
+Weight: 1
+
 Styleguide css.typography.bodycopy
 */
 
@@ -67,6 +71,8 @@ Styleguide css.typography.leadbodycopy
 Lists
 
 A collection of styles associated with creating lists.
+
+Weight: 2
 
 Styleguide css.typography.lists
 */
@@ -115,6 +121,8 @@ Markup:
   <li>Eget porttitor lorem</li>
 </ul>
 
+Weight: 1
+
 Styleguide css.typography.lists.ordered
 */
 
@@ -142,6 +150,8 @@ Markup:
   <li>Eget porttitor lorem</li>
 </ul>
 
+Weight: 1
+
 Styleguide css.typography.lists.unstyled
 */
 
@@ -156,6 +166,8 @@ Markup:
   <li>Consectetur adipiscing elit</li>
   <li>Integer molestie lorem at massa</li>
 </ul>
+
+Weight: 2
 
 Styleguide css.typography.lists.inline
 */
@@ -175,6 +187,8 @@ Markup:
   <dt>Malesuada porta</dt>
   <dd>Etiam porta sem malesuada magna mollis euismod.</dd>
 </dl>
+
+Weight: 3
 
 Styleguide css.typography.lists.description
 */
@@ -197,6 +211,8 @@ Markup:
   <dd>Fusce dapibus, tellus ac cursus commodo, tortor mauris condimentum nibh, ut fermentum massa justo sit amet risus.</dd>
 </dl>
 
+Weight: 3
+
 Styleguide css.typography.lists.horizontal
 */
 
@@ -207,6 +223,8 @@ Default styling of blockquotes.
 
 Markup:
 <blockquote>Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.</blockquote>
+
+Weight: 2
 
 Styleguide css.typography.blockquote
 */

--- a/styleguide/javascript/carousel.css
+++ b/styleguide/javascript/carousel.css
@@ -5,5 +5,7 @@ The slideshow below shows a generic plugin and component for cycling through ele
 
 Markup: carousel.hbs
 
+weight: 11
+
 Styleguide javascript.carousel
 */

--- a/styleguide/javascript/collapse.css
+++ b/styleguide/javascript/collapse.css
@@ -5,5 +5,7 @@ Get base styles and flexible support for collapsible components like accordions 
 
 Markup: collapse.hbs
 
+Weight: 10
+
 Styleguide javascript.collapse
 */

--- a/styleguide/javascript/dropdown.css
+++ b/styleguide/javascript/dropdown.css
@@ -5,5 +5,7 @@ Add dropdown menus to nearly anything with this simple plugin, including the nav
 
 Markup: dropdown.hbs
 
+weight: 3
+
 Styleguide javascript.dropdown
 */

--- a/styleguide/javascript/modal.css
+++ b/styleguide/javascript/modal.css
@@ -5,5 +5,7 @@ A rendered modal with header, body, and set of actions in the footer.
 
 Markup: modal.hbs
 
+Weight: 2
+
 Styleguide javascript.modal
 */

--- a/styleguide/javascript/popover.css
+++ b/styleguide/javascript/popover.css
@@ -5,5 +5,7 @@ Inspired by the excellent jQuery.tipsy plugin written by Jason Frame; Tooltips a
 
 Markup: popover.hbs
 
+Weight: 7
+
 Styleguide javascript.popover
 */

--- a/styleguide/javascript/tooltip.css
+++ b/styleguide/javascript/tooltip.css
@@ -5,5 +5,7 @@ Inspired by the excellent jQuery.tipsy plugin written by Jason Frame; Tooltips a
 
 Markup: javascript.tooltip
 
+Weight: 6
+
 Styleguide javascript.tooltip
 */


### PR DESCRIPTION
The official Bootstrap docs use a custom ordering of its components. kss-bootstrap currently has alphabetical sorting.

Since kss-node supports the "weight" property specifically for overriding the default alphabetical ordering, we should use weights.

I went through http://getbootstrap.com/css/, http://getbootstrap.com/components/ , and http://getbootstrap.com/javascript/ and used their ordering to add weights to kss-bootstrap's sections.